### PR TITLE
fix: Add grade range for outside

### DIFF
--- a/src/types/dreamy.ts
+++ b/src/types/dreamy.ts
@@ -37,12 +37,15 @@ export type GradePoint =
 export const gradeRangeAToC = [
   'A+',
   'A0',
+  'A',
   'A-',
   'B+',
   'B0',
+  'B',
   'B-',
   'C+',
   'C0',
+  'C',
   'C-',
 ] as const
 


### PR DESCRIPTION
외부 교류의 경우 4.5 학점제의 점수를 그대로 반영하고 있습니다.

업데이트한 상수는 파이 챠트를 그릴때만 쓰입니다.